### PR TITLE
Fixed base_java.jar folder location

### DIFF
--- a/webrtc-build/build.sh
+++ b/webrtc-build/build.sh
@@ -264,7 +264,7 @@ execute_build() {
 
         # Copy the jars
         cp -p "$SOURCE_DIR/lib.java/webrtc/sdk/android/libjingle_peerconnection_java.jar" "$TARGET_DIR/libs/libjingle_peerconnection.jar"
-        cp -p "$SOURCE_DIR/lib.java/webrtc/base/base_java.jar" "$TARGET_DIR/libs/base_java.jar"
+        cp -p "$SOURCE_DIR/lib.java/webrtc/rtc_base/base_java.jar" "$TARGET_DIR/libs/base_java.jar"
         cp -p "$SOURCE_DIR/lib.java/webrtc/modules/audio_device/audio_device_java.jar" "$TARGET_DIR/libs/audio_device_java.jar"
 
         # Strip the build only if its release


### PR DESCRIPTION
The base_java.jar file location had changed in the latest releases, instead of base now we have rtc_base.